### PR TITLE
CSE-1317 update sys-button documentation

### DIFF
--- a/javascript-sdk/widgets/sys-psv-button.md
+++ b/javascript-sdk/widgets/sys-psv-button.md
@@ -3,11 +3,13 @@
 Der SYS-PSV-Button weißt den Nutzer der Webseite darauf hin, dass es zum aktuell angesehenen Artikel ein passendes Produktset gibt.  
 Der Nutzer kann mit einem Klick auf den Button direkt zum Produktset runterscrollen oder springen.
 
-Ein beliebiges Element mit dem Attribut `data-8select-widget-id="sys-psv-button"` wird als SYS-PSV Button erkannt. Dieses Element sollte initial versteckt sein. Durch die Definition eines Callbacks wird der Button eingeblendet, wenn ein Produktset zum Artikel verfügbar ist.
+Ein beliebiges Element mit dem Attribut `data-8select-widget-id="sys-psv-button"` wird als SYS-PSV Button erkannt. Dieses Element sollte initial versteckt sein. Ist ein Produktset zum Artikel verfügbar, wird der Button automatisch eingeblendet.
 
 **Beispiel**
 
-```text
+HTML im Quellcode:
+
+```html
 <button
     data-8select-widget-id="sys-psv-button"
     onclick="_8select.utils.goToWidget(document.querySelectorAll('[data-8select-widget-id=sys-psv]')[0].getAttribute('data-8select-widget-uuid'), 0);"
@@ -17,22 +19,13 @@ Ein beliebiges Element mit dem Attribut `data-8select-widget-id="sys-psv-button"
   >Passender Look</button>
 ```
 
-```text
-window._eightselect_config = window._eightselect_config || {}
-window._eightselect_config['sys'] = {
-  callback: function (error, sku, widgetUuid) {
-    if (error) {
-      // something went wrong or no set was found for given sku
-      return
-    }
-    // everything fine and a set was found for given sku
-    // we can show a button that let's the customer know that we have a set and allows him/her to navigate to the widget with one click
-    document.querySelector('[data-8select-widget-id=sys-psv-button]').style.display = 'block'
-  }
+**Asynchrone Einbindung**
+
+Für den Fall, dass das SYS-PSV-Button-Element dynamisch erzeugt oder asynchron geladen wird, muss im Zuge dessen folgender JavaScript-Callback ausgeführt werden: 
+
+```javascript
+if (typeof _8select === "undefined") {
+  return
 }
+_8select.utils.showSysButton()
 ```
-
-```text
-_8select.utils.goToWidget(widgetUuid, offset)
-```
-


### PR DESCRIPTION
**Summary**:

for reference see: https://github.com/8select/widget-loader/pull/106

In SYS-Button documentation:
- removed `_eightselect_config` object definition, since we now call `_8select.utils.showSysButton()` directly alongside the `sys.callback` from within the `widget-loader`
- removed `goToWidget()` example since it is already integrated within the HTML button snippet for those who wan't to call it separately
- added add-on snippet for asynchronous injections of sys-button
- replaced markdown code `text` type with `html` and `javascript` for shiny syntax-highlighting 💎 